### PR TITLE
Ai spike

### DIFF
--- a/app/assets/stylesheets/components/_chat.scss
+++ b/app/assets/stylesheets/components/_chat.scss
@@ -1,0 +1,7 @@
+.chat-container {
+  height: 95vh;
+}
+
+// .chat-responses {
+//   overflow-y: auto;
+// }

--- a/app/assets/stylesheets/components/_chat.scss
+++ b/app/assets/stylesheets/components/_chat.scss
@@ -2,6 +2,6 @@
   height: 95vh;
 }
 
-// .chat-responses {
-//   overflow-y: auto;
-// }
+.chat-responses {
+  overflow-y: auto;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -6,3 +6,4 @@
 @import "homepage";
 @import "form";
 @import "priority";
+@import "chat";

--- a/app/controllers/conversation_responses_controller.rb
+++ b/app/controllers/conversation_responses_controller.rb
@@ -7,25 +7,7 @@ class ConversationResponsesController < ApplicationController
     prompt = params[:prompt]
 
     # Change this service whenever another is needed
-    # Need to pass in response -> add into chat_service too
-    ChatService::OpenAiCompletionStream.new(prompt: prompt).call
+    ChatService::GroqCompletionStream.new(prompt: prompt, response: response).call
 
-    # sse = SSE.new(response.stream, event: "message")
-    # client = OpenAI::Client.new(access_token: ENV['OPENAI_ACCESS_TOKEN'])
-    # begin
-      # client.chat(
-      #   parameters: {
-      #     model: "gpt-3.5-turbo-16k",
-      #     messages: [{ role: "user", content: params[:prompt] }],
-      #     stream: proc do |chunk|
-      #       content = chunk.dig('choices', 0, 'delta', 'content')
-      #       return if content.nil?
-      #       sse.write({ message: content })
-      #     end
-      #   }
-      # )
-    # ensure
-    #   sse.close
-    # end
   end
 end

--- a/app/controllers/conversation_responses_controller.rb
+++ b/app/controllers/conversation_responses_controller.rb
@@ -1,0 +1,31 @@
+class ConversationResponsesController < ApplicationController
+  include ActionController::Live # allows us to stream response based on server-sent events
+
+  def index
+    response.headers['Content-Type'] = "text/event-stream"
+    response.headers['Last-Modified'] = Time.now.httpdate
+    prompt = params[:prompt]
+
+    # Change this service whenever another is needed
+    # Need to pass in response -> add into chat_service too
+    ChatService::OpenAiCompletionStream.new(prompt: prompt).call
+
+    # sse = SSE.new(response.stream, event: "message")
+    # client = OpenAI::Client.new(access_token: ENV['OPENAI_ACCESS_TOKEN'])
+    # begin
+      # client.chat(
+      #   parameters: {
+      #     model: "gpt-3.5-turbo-16k",
+      #     messages: [{ role: "user", content: params[:prompt] }],
+      #     stream: proc do |chunk|
+      #       content = chunk.dig('choices', 0, 'delta', 'content')
+      #       return if content.nil?
+      #       sse.write({ message: content })
+      #     end
+      #   }
+      # )
+    # ensure
+    #   sse.close
+    # end
+  end
+end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -27,7 +27,7 @@ class ConversationsController < ApplicationController
   }
 
   # params = {
-  #     model: "gpt-3.5-turbo-16k",
+  #     model: "gpt-3.5-turbo-1106",
   #     name: "My Task Assistant",
   #     description: nil,
   #     instructions: "You are a productivity assistant. When asked a question, provide answers that can help the user fulfill his tasks.",
@@ -49,7 +49,7 @@ class ConversationsController < ApplicationController
 
   #   response = client.chat(
   #   parameters: {
-  #       model: "gpt-3.5-turbo-16k",
+  #       model: "gpt-3.5-turbo-1106",
   #       messages: [{ role: "user", content: "Tell me a joke!"}],
   #       temperature: 0.7,
   #   })

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -38,8 +38,13 @@ class ConversationsController < ApplicationController
   # my_asst = client.assistants.create(parameters: params)
 
   def index
-    @client = OpenAI::Client.new
-    @assistant_id = ENV.fetch("OPENAI_ASSISTANT_ID")
+    @chat = Chat.find(params[:chat_id])
+    @conversation = Conversation.new
+    # @response = ChatService::OpenAiCompletion.new(message: "What should I eat for breakfast today?").call
+    # @count = OpenAI.rough_token_count(@response)
+
+    # @client = OpenAI::Client.new
+    # @assistant_id = ENV.fetch("OPENAI_ASSISTANT_ID")
     # Note to team-mates: You can add raise here and type '@client.assistants.retrieve(assistant_id)' in browser console to see details of the assistant created
 
   #   response = client.chat(
@@ -50,6 +55,5 @@ class ConversationsController < ApplicationController
   #   })
   #   @message = response.dig("choices", 0, "message", "content")
   #   @count = OpenAI.rough_token_count(@message)
-    raise
   end
 end

--- a/app/javascript/controllers/conversation_controller.js
+++ b/app/javascript/controllers/conversation_controller.js
@@ -25,10 +25,11 @@ export default class extends Controller {
   }
 
   #createMessage(text) {
-    const content = document.createElement('p') // pre element preserves spaces and line breaks
-    content.innerText = `${text}`
-    this.responseTarget.appendChild(content)
-    return content
+    const contentElement = document.createElement('pre') // pre element preserves spaces and line breaks
+    contentElement.classList.add('text-break')
+    contentElement.innerText = `${text}`
+    this.responseTarget.appendChild(contentElement)
+    return contentElement
   }
 
   #setupEventSource() {

--- a/app/javascript/controllers/conversation_controller.js
+++ b/app/javascript/controllers/conversation_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="conversation"
+export default class extends Controller {
+  static targets = ["prompt", "response"]
+
+  connect() {
+    console.log("connected!");
+  }
+
+  generateResponse(event) {
+    event.preventDefault()
+    this.#createLabel('You')
+    this.#createMessage(this.promptTarget.value)
+    this.#createLabel('AI')
+    this.currentContent = this.#createMessage("")
+    this.#setupEventSource()
+    this.promptTarget.value = ""
+  }
+
+  #createLabel(text) {
+    const label = document.createElement('strong')
+    label.innerText = `${text}`
+    this.responseTarget.appendChild(label)
+  }
+
+  #createMessage(text) {
+    const content = document.createElement('p') // pre element preserves spaces and line breaks
+    content.innerText = `${text}`
+    this.responseTarget.appendChild(content)
+    return content
+  }
+
+  #setupEventSource() {
+    this.eventSource = new EventSource(`/conversation_responses?prompt=${this.promptTarget.value}`)
+    this.eventSource.addEventListener("message", this.#handleMessage.bind(this))
+    this.eventSource.addEventListener("error", this.#handleError.bind(this)) // we get this error event automatically once the server closes the connection
+  }
+
+  #handleMessage(event) {
+    const parsedData = JSON.parse(event.data)
+    this.currentContent.innerHTML += parsedData.message
+    this.responseTarget.scrollTop = this.responseTarget.scrollHeight
+  }
+
+  #handleError(event) {
+    if (event.eventPhase === EventSource.CLOSED) { // check that the server really did close the connection
+      this.eventSource.close() // then close the eventsource on the client
+    }
+  }
+
+  disconnect() {
+    if (this.eventSource) { // if event source somehow still open, close it!!
+      this.eventSource.close()
+    }
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :tasks
-  has_many :chats
+  has_many :tasks, dependent: :destroy
+  has_many :chats, dependent: :destroy
 end

--- a/app/services/chat_service.rb
+++ b/app/services/chat_service.rb
@@ -1,0 +1,65 @@
+class ChatService
+  include ActionController::Live # allows us to stream response based on server-sent events
+
+  attr_reader :message
+
+  def initialize(prompt:) # i.e. initialise with (message: "something")
+    @prompt = prompt
+  end
+
+  class OpenAiCompletion < ChatService
+    # In rails c, test with "ChatService::OpenAiCompletion.new(prompt: "I need something to cheer me up").call"
+
+    def call
+      messages = persona_instructions.map do |instruction|
+        { role: "system", content: instruction}
+      end
+
+      messages << { role: "user", content: prompt}
+
+      response = client.chat(
+        parameters: {
+          model: "gpt-3.5-turbo-16k", # Can consider swapping to cheaper model
+          messages: messages,
+          temperature: 0.7,
+        })
+        response.dig("choices", 0, "message", "content")
+    end
+
+    private
+
+    def persona_instructions
+      [
+        "You are a famous chef that loves to share simple, easy-to-cook recipes."
+      ]
+    end
+  end
+
+  class OpenAiCompletionStream < ChatService
+    def call
+      sse = SSE.new(response.stream, event: "message")
+      begin
+        client.chat(
+          parameters: {
+            model: "gpt-3.5-turbo-16k",
+            messages: [{ role: "user", content: prompt }],
+            stream: proc do |chunk|
+              content = chunk.dig('choices', 0, 'delta', 'content')
+              return if content.nil?
+              sse.write({ message: content })
+            end
+          }
+        )
+      ensure
+        sse.close
+      end
+    end
+  end
+
+  private
+
+  # Set client as instance variable and initialise only once so we can use the same client instance throughout
+  def client
+    @_client ||= OpenAI::Client.new
+  end
+end

--- a/app/services/chat_service.rb
+++ b/app/services/chat_service.rb
@@ -19,7 +19,7 @@ class ChatService
 
       response = client.chat(
         parameters: {
-          model: "gpt-3.5-turbo-16k", # Can consider swapping to cheaper model
+          model: "gpt-3.5-turbo-1106", # Can consider swapping to cheaper model
           messages: messages,
           temperature: 0.7,
         })
@@ -33,16 +33,29 @@ class ChatService
         "You are a famous chef that loves to share simple, easy-to-cook recipes."
       ]
     end
+
+    # Set client as instance variable and initialise only once so we can use the same client instance throughout
+    def client
+      @_client ||= OpenAI::Client.new(
+        access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"),
+        log_errors: true
+      )
+    end
   end
 
   class OpenAiCompletionStream < ChatService
+    def initialize(prompt:, response:)
+      @prompt = prompt
+      @response = response
+    end
+
     def call
-      sse = SSE.new(response.stream, event: "message")
+      sse = SSE.new(@response.stream, event: "message")
       begin
         client.chat(
           parameters: {
-            model: "gpt-3.5-turbo-16k",
-            messages: [{ role: "user", content: prompt }],
+            model: "gpt-3.5-turbo-1106",
+            messages: [{ role: "user", content: @prompt }],
             stream: proc do |chunk|
               content = chunk.dig('choices', 0, 'delta', 'content')
               return if content.nil?
@@ -54,12 +67,52 @@ class ChatService
         sse.close
       end
     end
+
+    private
+
+    def client
+      @_client ||= OpenAI::Client.new(
+        access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"),
+        log_errors: true
+      )
+    end
   end
 
-  private
+  class GroqCompletionStream < ChatService
+    # Consider refactor using https://github.com/drnic/groq-ruby
+    def initialize(prompt:, response:)
+      @prompt = prompt
+      @response = response
+    end
 
-  # Set client as instance variable and initialise only once so we can use the same client instance throughout
-  def client
-    @_client ||= OpenAI::Client.new
+    def call
+      sse = SSE.new(@response.stream, event: "message")
+      begin
+        client.chat(
+          parameters: {
+            model: "llama3-70b-8192",
+            messages: [{ role: "user", content: @prompt }],
+            stream: proc do |chunk|
+              content = chunk.dig('choices', 0, 'delta', 'content')
+              return if content.nil?
+              sse.write({ message: content })
+            end
+          }
+        )
+      ensure
+        sse.close
+      end
+    end
+
+    private
+
+    def client
+      @_client ||= OpenAI::Client.new(
+        access_token: ENV.fetch('GROQ_ACCESS_TOKEN'),
+        uri_base: "https://api.groq.com/openai",
+        log_errors: true
+      )
+    end
   end
+
 end

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,4 +1,18 @@
-<h1>Talk to me, Seymour</h1>
+<div class="d-flex flex-column chat-container container" data-controller="conversation">
+  <h1>Talk to me, AI</h1>
 
-<p><%= @message %></p>
-<p>token count = <%= @count %></p>
+  <section class="chat-responses flex-grow-1" data-conversation-target="response">
+
+  </section>
+
+  <div class="flex-shrink-0">
+    <%= simple_form_for [ @chat, @conversation ], data: { action: "conversation#generateResponse" } do |f| %>
+      <%= f.input :user_message, input_html: { data: { conversation_target: "prompt" } } %>
+      <%= f.submit class:"btn btn-primary mt-3" %>
+    <% end %>
+  </div>
+
+  <p><%= @response %></p>
+  <p>token count = <%= @count %></p>
+
+</div>

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,8 +1,7 @@
 <div class="d-flex flex-column chat-container container" data-controller="conversation">
   <h1>Talk to me, AI</h1>
 
-  <section class="chat-responses flex-grow-1" data-conversation-target="response">
-
+  <section class="chat-responses flex-grow-1 text-wrap" data-conversation-target="response">
   </section>
 
   <div class="flex-shrink-0">
@@ -11,8 +10,4 @@
       <%= f.submit class:"btn btn-primary mt-3" %>
     <% end %>
   </div>
-
-  <p><%= @response %></p>
-  <p>token count = <%= @count %></p>
-
 </div>

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,4 +1,0 @@
-OpenAI.configure do |config|
-  config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
-  config.log_errors = true # Highly recommended in development, so you can see what errors OpenAI is returning. Not recommended in production.
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :chats, only: [ :index, :show, :create, :delete ] do
     resources :conversations, only: [ :index, :new, :create, :show ]
   end
+  resources :conversation_responses, only: [ :index ]
 
   # if we would like for the url to be custom /logslols/username
   # get '*username', to: 'pages#home'

--- a/test/controllers/conversation_responses_controller_test.rb
+++ b/test/controllers/conversation_responses_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ConversationResponsesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
**Completed**
1. Set up chat_service file to run any ai services. Current nested services for openai and groq. This build defaults to groq which is free
3. Frontend set up on temporary path: http://localhost:3000/chats/2/conversations (note: the chat id to insert depends on your own db)
5. Sequence: a) User types query on page above, b) stimulus controller 'conversations' fetches the route managed by conversations_responses controller which calls the respective ai service at chat_service.rb, c) stimulus controller gets the stream and renders it back on the page

**Known issues**
1. Using 'pre' tag element preserves line breaks but causes long text to overflow and invokes scroll. 