### PR TITLE
Fixed get_tasks_due notification

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -75,7 +75,7 @@ class TasksController < ApplicationController
 
   def get_tasks_due
     current_time = Time.zone.now
-    @tasks = Task.where("reminder_datetime <= ? AND status != ?", current_time, 'notified')
+    @tasks = Task.where.not(reminder_datetime: nil)
     reminders = @tasks
 
     ReminderChannel.broadcast_to(
@@ -86,7 +86,7 @@ class TasksController < ApplicationController
       }
     )
 
-    @tasks.update_all(status: 'notified')
+    @tasks.update_all(reminder_datetime: nil)
     head :ok
   end
 

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1,0 +1,14 @@
+namespace :tasks do
+  desc "Update the notification dates of some Tasks"
+  task renotify: :environment do
+    task_titles = ["Event Planning", "Financial Management", "Health and Wellness"]
+    tasks = task_titles.map { |title| Task.find_by(title:) }
+
+    tasks.each do |task|
+      task.reminder_datetime = DateTime.new(2024, 05, 19, 15, 30, 00)
+      task.save!
+    end
+
+    puts "tasks renotified"
+  end
+end


### PR DESCRIPTION
### Task Controller
- removed change of task.status to `notified`
- pulled pending notifications based on `reminder_datetime` not being nil
- cleared `reminder_datetime` after sending notification 

### Tasks:Renotify
- added rake task `tasks:renotify`
- allows the renotification of tasks without needing to call `rails db:seed`