### PR TITLE
Bug fix stimulus

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -30,7 +30,7 @@ class TasksController < ApplicationController
         format.json
         flash[:notice] = "'#{@task.title}' task successfully saved!"
       else
-        format.html
+        format.html { render partial: 'new', status: :unprocessable_entity }
         format.json
       end
     end

--- a/app/javascript/controllers/new_task_controller.js
+++ b/app/javascript/controllers/new_task_controller.js
@@ -8,21 +8,33 @@ export default class extends Controller {
     this.handleDocumentClick = this.handleDocumentClick.bind(this)
   }
 
-  async addNewTask() {
-    this.newcontentTarget.classList.toggle("active")
+  // when clicking on the button
+  // pop up appears
+  // create form appears
+
+  openCreate() {
+    this.newcontentTarget.classList.add("active")
+
     const url = '/tasks/new'
-
-    const response = await fetch(url, {
-      headers: { 'Accept': 'text/plain'
-      }
-    });
-
-    const newContent = await response.text();
-    this.newcontentTarget.innerHTML = newContent
-    // document.addEventListener("click", this.handleDocumentClick);
+    fetch(url, {
+      headers: { 'Accept': 'text/plain' }
+    })
+    .then(response => response.text())
+    .then((data) => {
+      this.newcontentTarget.innerHTML = data ;
+      document.addEventListener("click", this.handleDocumentClick);
+    })
   }
 
-  send(e) {
+
+  closeCreate() {
+    this.newcontentTarget.classList.remove("active")
+  }
+
+  // listens to submit button on form
+  // prevents default action
+
+  submit(e) {
     e.preventDefault()
     fetch(this.formTarget.action, {
       method: "POST",
@@ -31,15 +43,17 @@ export default class extends Controller {
     })
     .then(response => response.json())
     .then((data) => {
-      this.formTarget.outerHTML = data.form
-      this.newcontentTarget.classList.remove("active")
 
       if (data.inserted_item) {
         this.insertformTarget.insertAdjacentHTML("afterbegin", data.inserted_item)
+        this.newcontentTarget.classList.remove("active")
       }
+      this.formTarget.outerHTML = data.form
     })
   }
 
+
+  // to close the card anywhere on the page
 
   close() {
     this.newcontentTarget.classList.remove("active")

--- a/app/javascript/controllers/sliding_effect_controller.js
+++ b/app/javascript/controllers/sliding_effect_controller.js
@@ -46,7 +46,6 @@ export default class extends Controller {
   // fetch form from edit and display on the card.
 
   openEdit() {
-    console.log(this.contentTarget.innerHTML);
     this.contentTarget.classList.add("active")
 
     const url = `/tasks/${this.idValue}/edit`
@@ -65,7 +64,6 @@ export default class extends Controller {
   // card should go back to original content
 
   closeEdit() {
-    console.log('can close');
     this.contentTarget.classList.remove("active")
     this.contentTarget.innerHTML = this.originalContent
   }
@@ -86,8 +84,6 @@ export default class extends Controller {
     })
     .then(response => response.text())
     .then((data) => {
-      console.log(this.originalContent);
-      console.log(data);
       this.contentTarget.classList.remove("active")
       this.contentTarget.innerHTML = data
       // this.contentTarget.outerHTML = data
@@ -109,6 +105,9 @@ export default class extends Controller {
     this.contentTarget.innerHTML = newContent
   }
 
+
+  // to close the card anywhere on the page
+
   close() {
     this.contentTarget.classList.remove("active")
     this.resetContent()
@@ -127,6 +126,9 @@ export default class extends Controller {
     this.contentTarget.innerHTML = this.originalContent
   }
 
+  // to make sure check box is corrected
+  // need to replace from this.originalContent too
+  
   toggleCheckbox(event) {
     if (event.currentTarget.className.contains('fa-regular')) {
       event.currentTarget.className = event.currentTarget.className.replace('fa-regular', 'fa-solid')

--- a/app/javascript/controllers/sliding_effect_controller.js
+++ b/app/javascript/controllers/sliding_effect_controller.js
@@ -7,67 +7,75 @@ export default class extends Controller {
 
   connect() {
     this.originalContent = this.contentTarget.innerHTML
-    this.isOriginal = true
     this.handleDocumentClick = this.handleDocumentClick.bind(this)
     this.csrfToken = document.head.querySelector("[name~=csrf-token][content]").content;
   }
 
-  async toggleSlide() {
-    this.contentTarget.classList.toggle("active");
+  // showing more details of the card
+  // when pressing the button on the small card,
+  // document add class of active to make it bigger
+  // document fetches the new display to display.
+
+
+  openCard() {
+    this.contentTarget.classList.add("active")
+
     const url = `/tasks/${this.idValue}`
-
-    if (this.isOriginal) {
-      try {
-        const response = await fetch(url , {
-          headers: { 'Accept': 'text/plain'
-          }
-        });
-        if (response.ok) {
-          const newContent = await response.text();
-          this.contentTarget.innerHTML = newContent
-          // TODO: find a way to scroll this shit
-        } else {
-          console.error("Failed to load new content");
-        }
-      } catch (error) {
-        console.error("Error fetching new content", error);
-      }
-    } else {
-      this.contentTarget.innerHTML = this.originalContent;
-    }
-    // document.addEventListener("click", this.handleDocumentClick);
-    this.isOriginal = !this.isOriginal;
-
-    console.log(this.originalContent);
+    fetch (url, { headers: {
+      "Accept": "text/plain" },
+    })
+    .then(response => response.text())
+    .then((data) => {
+      this.contentTarget.innerHTML = data
+      // console.log(data);
+    })
+    document.addEventListener("click", this.handleDocumentClick);
   }
 
-  async loadEdit() {
-    this.contentTarget.classList.toggle("active");
+  // press the button on the form itself
+  // card should be able to close
+  // card should go back to original content
+
+  closeCard() {
+    this.contentTarget.classList.remove("active")
+    this.contentTarget.innerHTML = this.originalContent
+  }
+
+  // load edit page
+  // press the icon, card should zoom in
+  // fetch form from edit and display on the card.
+
+  openEdit() {
+    console.log(this.contentTarget.innerHTML);
+    this.contentTarget.classList.add("active")
+
     const url = `/tasks/${this.idValue}/edit`
-
-    if (this.isOriginal) {
-      try {
-        const response = await fetch(url , {
-          headers: { 'Accept': 'text/plain'
-          }
-        });
-        if (response.ok) {
-          const newContent = await response.text();
-          this.contentTarget.innerHTML = newContent
-        } else {
-          console.error("Failed to load new content");
-        }
-      } catch (error) {
-        console.error("Error fetching new content", error);
-      }
-    } else {
-      this.contentTarget.innerHTML = this.originalContent;
-    }
-    // document.addEventListener("click", this.handleDocumentClick);
-    this.isOriginal = !this.isOriginal;
+    fetch (url, { headers: {
+      "Accept": "text/plain" },
+    })
+    .then(response => response.text())
+    .then((data) => {
+      this.contentTarget.innerHTML = data
+    })
+    document.addEventListener("click", this.handleDocumentClick);
   }
 
-  send(e) {
+  // close edit form by pressing the arrow button on the inside
+  // card should minimize
+  // card should go back to original content
+
+  closeEdit() {
+    console.log('can close');
+    this.contentTarget.classList.remove("active")
+    this.contentTarget.innerHTML = this.originalContent
+  }
+
+  // update the form once it is edited
+  // need to listen to submit and fetch the patch details
+  // update form accordingly
+  // update this.originalContent so that form remains the same no matter what.
+
+  update(e) {
     e.preventDefault()
     fetch(this.formTarget.action, {
       method: 'PATCH',
@@ -78,9 +86,16 @@ export default class extends Controller {
     })
     .then(response => response.text())
     .then((data) => {
-      this.contentTarget.outerHTML = data
+      console.log(this.originalContent);
+      console.log(data);
+      this.contentTarget.classList.remove("active")
+      this.contentTarget.innerHTML = data
+      // this.contentTarget.outerHTML = data
+      this.originalContent = data
     })
   }
+
+  // brings you to edit form from 'more details' page
 
   async changeEdit() {
     console.log("changed");

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -24,7 +24,7 @@
           <div class="mt-4 position relative home-icons col-1 d-flex flex-column align-items-center justify-content-start">
             <p><i class="fa-regular fa-calendar fs-3"></i></p>
             <p><i class="fa-solid fa-chalkboard fs-3"></i></p>
-            <p data-action="click->new-task#addNewTask"><i class="fa-regular fa-square-plus fs-3"></i></p>
+            <p data-action="click->new-task#openCreate"><i class="fa-regular fa-square-plus fs-3"></i></p>
             <div class="new-task popup" data-new-task-target="newcontent">
             </div>
           </div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -3,7 +3,7 @@
         new_task_target: "form",
         sliding_effect_target: "form",
         action: "submit->new-task#send",
-        action: "submit->sliding-effect#send"
+        action: "submit->sliding-effect#update"
     } do |f| %>
 
     <%= f.input :title, label: "name of task" %>
@@ -39,7 +39,7 @@
     <div class="d-flex justify-content-between align-items-center">
       <%= f.submit class:"btn btn-primary mt-3" %>
         <% if @task.persisted? %>
-      <p data-action="click->sliding-effect#loadEdit" class="task-icons"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
+      <p data-action="click->sliding-effect#closeEdit" class="task-icons"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
       <% else %>
         <p data-action="click->new-task#addNewTask" class="task-icons"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
       <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -2,8 +2,7 @@
     data: {
         new_task_target: "form",
         sliding_effect_target: "form",
-        action: "submit->new-task#send",
-        action: "submit->sliding-effect#update"
+        action: ("submit->new-task#submit submit->sliding-effect#update")
     } do |f| %>
 
     <%= f.input :title, label: "name of task" %>
@@ -41,7 +40,7 @@
         <% if @task.persisted? %>
       <p data-action="click->sliding-effect#closeEdit" class="task-icons"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
       <% else %>
-        <p data-action="click->new-task#addNewTask" class="task-icons"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
+        <p data-action="click->new-task#closeCreate" class="task-icons"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
       <% end %>
     </div>
   <% end %>

--- a/app/views/tasks/_index.html.erb
+++ b/app/views/tasks/_index.html.erb
@@ -1,9 +1,3 @@
 <% tasks.each_with_index do |task, index| %>
-  <div id="task-<%= task.id %>" class="col-4 d-flex justify-content-center mb-1 <%= task.status === "due" && "task-due" %>">
-    <div class="task position-relative" data-controller="sliding-effect" data-sliding-effect-id-value="<%= task.id %>">
-      <div class="tasks-cards d-flex flex-column position-absolute top-0 <%= index % 3 === 0 ? "start-0": "end-0" %>" data-sliding-effect-target="content">
-        <%= render "tasks/task", task: task, index: index %>
-      </div>
-    </div>
-  </div>
+  <%= render "tasks/newtask", task: task, index: index %>
 <% end %>

--- a/app/views/tasks/_index.html.erb
+++ b/app/views/tasks/_index.html.erb
@@ -1,7 +1,9 @@
 <% tasks.each_with_index do |task, index| %>
   <div id="task-<%= task.id %>" class="col-4 d-flex justify-content-center mb-1 <%= task.status === "due" && "task-due" %>">
     <div class="task position-relative" data-controller="sliding-effect" data-sliding-effect-id-value="<%= task.id %>">
-      <%= render "tasks/task", task: task, index: index %>
+      <div class="tasks-cards d-flex flex-column position-absolute top-0 <%= index % 3 === 0 ? "start-0": "end-0" %>" data-sliding-effect-target="content">
+        <%= render "tasks/task", task: task, index: index %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/tasks/_newtask.html.erb
+++ b/app/views/tasks/_newtask.html.erb
@@ -1,0 +1,7 @@
+<div id="task-<%= task.id %>" class="col-4 d-flex justify-content-center mb-1 <%= task.status === "due" && "task-due" %>">
+    <div class="task position-relative" data-controller="sliding-effect" data-sliding-effect-id-value="<%= task.id %>">
+      <div class="tasks-cards d-flex flex-column position-absolute top-0 <%= index % 3 === 0 ? "start-0": "end-0" %>" data-sliding-effect-target="content">
+        <%= render "tasks/task", task: task, index: index %>
+      </div>
+    </div>
+  </div>

--- a/app/views/tasks/_show.html.erb
+++ b/app/views/tasks/_show.html.erb
@@ -36,7 +36,7 @@
     </div>
 
     <div class="col-1 d-flex flex-column justify-content-end">
-      <p class="task-icons" data-action="click->sliding-effect#toggleSlide"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
+      <p class="task-icons" data-action="click->sliding-effect#closeCard"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
 
       <p class="task-icons"><i class="<%= task.status === "Complete" ? "fa-solid" : "fa-regular" %> fa-circle-check btn px-0 border-0" data-sliding-effect-target="checkbox" data-action="click->sliding-effect#toggleCheckbox"></i></p>
 

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,11 +1,11 @@
-<div class="tasks-cards d-flex flex-column position-absolute top-0 <%= index % 3 === 0 ? "start-0": "end-0" %>" data-sliding-effect-target="content">
+
   <div class="flex-grow-1 px-1">
     <div class="d-flex align-items-center mb-2">
       <p class="tasks-date m-0 flex-grow-1">Due: <%= task.due_date %></p>
       <% if task.reminder_datetime %>
         <i class="fa-regular fa-bell fs-5"></i>
       <% end %>
-      <p class="task-icons" data-action="click->sliding-effect#toggleSlide"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
+      <p class="task-icons" data-action="click->sliding-effect#openCard"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
 
     </div>
 
@@ -38,7 +38,7 @@
     <p class="task-icons"><%= link_to task_path(task), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } do %>
       <i class="fa-regular fa-trash-can text-dark"></i>
     <% end %></p>
-    <p data-action="click->sliding-effect#loadEdit" class="task-icons"><i class="fa-regular fa-pen-to-square"></i></p>
+    <p data-action="click->sliding-effect#openEdit" class="task-icons"><i class="fa-regular fa-pen-to-square"></i></p>
 
   </div>
-</div>
+

--- a/app/views/tasks/create.json.jbuilder
+++ b/app/views/tasks/create.json.jbuilder
@@ -7,7 +7,7 @@
 
 if @task.persisted?
   json.form render(partial: "tasks/form", formats: :html, locals: {task: Task.new})
-  json.inserted_item render(partial: "tasks/task", formats: :html, locals: { task: @task, index: 0})
+  json.inserted_item render(partial: "tasks/newtask", formats: :html, locals: { task: @task, index: 0})
 else
   json.form render(partial: "tasks/form", formats: :html, locals: {task: @task})
 end


### PR DESCRIPTION
aggressively test ALL features PLEASE
think i managed to resolve almost all of the bugs that was happening yesterday. 
1. create does not reload the page anymore and adds straight to the homepage
2. edit updates the page immediately too
3. updated content after edit doesn't change even if you click other buttons
4. you can play spotify to check whether page reloads while doing the above (so you no need to second guess if the page is actually reloading anot)

known bugs still:
flatpickr still kind off glitches when clicking anywhere on the page to close is enabled. (might have to disable 'click to close anywhere'
alerts kinda still does not work.
i did notice some of the cards changing their opening orientation (hence blocked by the chatbox when it opens), refers to note on this issue below. 

to check:
whether updating a task refreshes it’s index. if yes, its the reason why some cards open the other side after getting refreshed. try out cards tmr to see if it works or not.