### PR TITLE
tasks opening function works based on nth:child, header truncated.

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -4,3 +4,4 @@
 //= link_tree ../../../vendor/javascript .js
 //= link popper.js
 //= link bootstrap.min.js
+//= link application.css

--- a/app/assets/stylesheets/components/_homepage.scss
+++ b/app/assets/stylesheets/components/_homepage.scss
@@ -42,11 +42,6 @@
   display: block;
 }
 
-.task {
-  width: 243px;
-  height: 230px;
-  margin: 10px;
-}
 
 .task-font-size > h2 {
   font-size: 24px;
@@ -54,6 +49,13 @@
 
 .task-font-size > p {
   font-size: 14px;
+}
+
+.task {
+  width: 243px;
+  height: 230px;
+  margin: 10px;
+  position: relative;
 }
 
 .tasks-cards {
@@ -65,8 +67,9 @@
   border-radius: 22px;
   transition: all 0.5s;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-}
+  position: absolute;
 
+}
 
 .tasks-date {
   font-size: 15px;
@@ -107,6 +110,13 @@
   border-radius: 25px;
   position: fixed;
   z-index: 10;
+  position: absolute;
+
+}
+
+.col-4:nth-child(3n) > .task > .tasks-cards {
+  position: absolute;
+  right: 0;
 }
 
 body {

--- a/app/assets/stylesheets/components/_showpage.scss
+++ b/app/assets/stylesheets/components/_showpage.scss
@@ -14,6 +14,10 @@
   transition: all 0.5s;
 }
 
+.task-description {
+  width: 100%;
+  height: 350px;
+}
 
 // .edit {
 //   position: fixed;

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -37,12 +37,10 @@ class TasksController < ApplicationController
   end
 
   def original
-    tasks = Task.all
-    @index = tasks.index(@task)
     respond_to do |format|
       format.html
       # format.text { render plain: 'test' }
-      format.text { render partial: 'tasks/task', locals: { task: @task, index: @index }, formats: [:html] }
+      format.text { render partial: 'tasks/task', locals: { task: @task }, formats: [:html] }
     end
   end
 
@@ -54,8 +52,6 @@ class TasksController < ApplicationController
   end
 
   def update
-    tasks = Task.all
-    @index = tasks.index(@task)
     respond_to do |format|
       if @task.update(task_params.except(:documents))
         @task.documents.attach(task_params[:documents])

--- a/app/views/tasks/_index.html.erb
+++ b/app/views/tasks/_index.html.erb
@@ -1,3 +1,3 @@
-<% tasks.each_with_index do |task, index| %>
-  <%= render "tasks/newtask", task: task, index: index %>
+<% tasks.each do |task| %>
+  <%= render "tasks/newtask", task: task %>
 <% end %>

--- a/app/views/tasks/_newtask.html.erb
+++ b/app/views/tasks/_newtask.html.erb
@@ -1,7 +1,7 @@
 <div class="col-4 d-flex justify-content-center mb-1 <%= task.status === "due" && "task-due" %>">
-    <div class="task position-relative">
-      <div data-id="<%= task.id %>" data-task-cards-target="content" class="tasks-cards d-flex flex-column position-absolute top-0 <%= index % 3 === 0 ? "start-0": "end-0" %>">
-        <%= render "tasks/task", task: task, index: index %>
+    <div class="task">
+      <div data-id="<%= task.id %>" data-task-cards-target="content" class="tasks-cards d-flex flex-column">
+        <%= render "tasks/task", task: task %>
       </div>
     </div>
   </div>

--- a/app/views/tasks/_show.html.erb
+++ b/app/views/tasks/_show.html.erb
@@ -20,9 +20,11 @@
       </div>
 
       <h1><%= @task.title %></h1>
-      <p><%= @task.description %></p>
+      <div class="task-description overflow-auto">
+        <p><%= @task.description %></p>
+      </div>
 
-      <div class="row">
+      <div class="row position-fixed bottom-0 mb-4">
       <% @task.documents.each do |doc| %>
         <% url = cloudinary_url(doc.key) %>
         <% image_url = url.sub('/upload/', '/upload/f_jpg/') %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class="task-font-size px-2">
-      <h2><%= task.title.truncate(35) %></h2>
+      <h2><%= task.title.truncate(27) %></h2>
 
       <p class= "mt-2"><%= task.description.truncate(50) %></p>
     </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class="task-font-size px-2">
-      <h2><%= task.title %></h2>
+      <h2><%= task.title.truncate(35) %></h2>
 
       <p class= "mt-2"><%= task.description.truncate(50) %></p>
     </div>

--- a/app/views/tasks/create.json.jbuilder
+++ b/app/views/tasks/create.json.jbuilder
@@ -1,6 +1,6 @@
 if @task.persisted?
   json.form render(partial: "tasks/form", formats: :html, locals: {task: Task.new})
-  json.inserted_item render(partial: "tasks/newtask", formats: :html, locals: { task: @task, index: 0})
+  json.inserted_item render(partial: "tasks/newtask", formats: :html, locals: { task: @task})
 else
   json.form render(partial: "tasks/form", formats: :html, locals: {task: @task})
 end

--- a/app/views/tasks/update.json.jbuilder
+++ b/app/views/tasks/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.updated_form render(partial: 'tasks/task', formats: [:html], locals: { task: @task, index: 1 })
+json.updated_form render(partial: 'tasks/task', formats: [:html], locals: { task: @task })


### PR DESCRIPTION
removed index for all partials.
the side the card opens from works on nth-child(3n) now instead of the index, hence index is redundant. 

header for the small cards view on home page has also been truncated. only allow a max of 2 lines.

nothing has crashed so far, please do testings to check. 
* use spotify to be 100% sure page is not reloading *