### PR TITLE
Enabled memory

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,0 +1,11 @@
+class ChatsController < ApplicationController
+  def index
+    @chat = Chat.last
+    render json: { chat_id: @chat.id }
+  end
+
+  def create
+    @chat = Chat.create!(user: current_user)
+    render json: { chat_id: @chat.id }
+  end
+end

--- a/app/controllers/conversation_responses_controller.rb
+++ b/app/controllers/conversation_responses_controller.rb
@@ -5,12 +5,14 @@ class ConversationResponsesController < ApplicationController
     response.headers['Content-Type'] = "text/event-stream"
     response.headers['Last-Modified'] = Time.now.httpdate
     prompt = params[:prompt]
+    chat_number = params[:chat_number]
+
     # Change this service whenever another is needed
     begin
-      GroqchatService::ToolUseStream.new(prompt: prompt, response: response).call
+      GroqchatService::ToolUseStream.new(prompt: prompt, response: response, user: current_user, chat_number: chat_number).call
     rescue StandardError => e
       puts "An error occurred: #{e.message}"
-      GroqchatService::RescueStream.new(response: response).call
+      GroqchatService::RescueStream.new(response: response, user: current_user, chat_number: chat_number).call
     end
 
   end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,33 +1,5 @@
 class ConversationsController < ApplicationController
-
-  # params = {
-  #     model: "gpt-3.5-turbo-1106",
-  #     name: "My Task Assistant",
-  #     description: nil,
-  #     instructions: "You are a productivity assistant. When asked a question, provide answers that can help the user fulfill his tasks.",
-  #     tools: [ WEATHER_TOOL ],
-  #     # "metadata": { my_internal_version_id: "1.0.0" }
-  # }
-
-  # my_asst = client.assistants.create(parameters: params)
-
   def index
-    @chat = Chat.find(params[:chat_id])
-    @conversation = Conversation.new
-    # @response = ChatService::OpenAiCompletion.new(message: "What should I eat for breakfast today?").call
-    # @count = OpenAI.rough_token_count(@response)
-
-    # @client = OpenAI::Client.new
-    # @assistant_id = ENV.fetch("OPENAI_ASSISTANT_ID")
-    # Note to team-mates: You can add raise here and type '@client.assistants.retrieve(assistant_id)' in browser console to see details of the assistant created
-
-  #   response = client.chat(
-  #   parameters: {
-  #       model: "gpt-3.5-turbo-1106",
-  #       messages: [{ role: "user", content: "Tell me a joke!"}],
-  #       temperature: 0.7,
-  #   })
-  #   @message = response.dig("choices", 0, "message", "content")
-  #   @count = OpenAI.rough_token_count(@message)
+    @user = current_user
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,8 +2,7 @@ class PagesController < ApplicationController
   # skip_before_action :authenticate_user!, only: [ :home ]
 
   def home
-    @tasks = current_user.tasks.order(:id).reverse
-    @chat = current_user.chats.where(status: "current")[0]
-    @conversation = Conversation.new
+    @user = current_user
+    @tasks = @user.tasks.order(:id).reverse
   end
 end

--- a/app/javascript/controllers/conversation_controller.js
+++ b/app/javascript/controllers/conversation_controller.js
@@ -7,6 +7,17 @@ export default class extends Controller {
   connect() {
     console.log("connected!");
     this.csrfToken = document.head.querySelector("[name~=csrf-token][content]").content;
+    const url = '/chats'
+    fetch(url, {
+      headers: {
+        "X-CSRF-Token": this.csrfToken,
+        "Accept": "application/json"
+      }
+    })
+    .then(response => response.json())
+    .then((data) => {
+      this.chatNumber = data.chat_id
+    })
   }
 
   generateResponse(event) {
@@ -17,6 +28,22 @@ export default class extends Controller {
     this.currentContent = this.#createMessage("")
     this.#setupEventSource()
     this.promptTarget.value = ""
+  }
+
+  resetChat(event) {
+    this.responseTarget.innerHTML = ''
+    const url = '/chats'
+    fetch(url, {
+      method: "POST",
+      headers: {
+        "X-CSRF-Token": this.csrfToken,
+        "Accept": "application/json"
+      }
+    })
+    .then(response => response.json())
+    .then((data) => {
+      this.chatNumber = data.chat_id
+    })
   }
 
   #createLabel(text) {
@@ -35,7 +62,7 @@ export default class extends Controller {
   }
 
   #setupEventSource() {
-    this.eventSource = new EventSource(`/conversation_responses?prompt=${this.promptTarget.value}`)
+    this.eventSource = new EventSource(`/conversation_responses?prompt=${this.promptTarget.value}&chat_number=${this.chatNumber}`)
     this.eventSource.addEventListener("message", this.#handleMessage.bind(this))
     this.eventSource.addEventListener("error", this.#handleError.bind(this)) // we get this error event automatically once the server closes the connection
   }

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,5 +1,3 @@
 class Conversation < ApplicationRecord
   belongs_to :chat
-
-  validates :user_message, presence: true
 end

--- a/app/services/groqchat_service.rb
+++ b/app/services/groqchat_service.rb
@@ -38,15 +38,8 @@ class GroqchatService
 
   class ToolUseStream < GroqchatService
     def call
-      messages = [
-        S(%q(
-          You are a friendly assistant who is provided with tools to find answers for the user. If a tool is relevant, you should incorporate the tool's response in your answer to the user. For example, based on a function call to 'get_weather_report', you receive the information of "35 degrees celsius. So hot". You should then include the specific mention of '35 degrees celsius' in your response to the user. You should never mention the tool, and never mention it is from a tool, and never mention it is from a tool. But if there are no relevant tools, answer as yourself. If url sources are provided, cite them with the anchor tag intact.
-          )),
-        U(@prompt)
-      ]
-
       # System instructions
-      instructions = S(%q(You are a friendly assistant who is provided with tools to find answers for the user. If a tool is relevant, you should incorporate the tool's response in your answer to the user. For example, based on a function call to 'get_weather_report', you receive the information of "35 degrees celsius. So hot". You should then include the specific mention of '35 degrees celsius' in your response to the user. You should never mention the tool. But if there are no relevant tools, answer as yourself.))
+      instructions = S(%q(You are a friendly assistant who is provided with tools to find answers for the user. If a tool is relevant, you should incorporate the tool's response in your answer to the user. For example, based on a function call to 'get_weather_report', you receive the information of "35 degrees celsius. So hot". You should then include the specific mention of '35 degrees celsius' in your response to the user, and never mention it is from a tool. But if there are no relevant tools, answer as yourself. If url sources are provided, cite them with the anchor tag intact.))
 
       # User prompt
       prompt_msg = U(@prompt)
@@ -86,13 +79,12 @@ class GroqchatService
         pp messages
         return get_final_response(@response, messages)
       else
-        # If tool exists, call it
+        # If tool exists, call it and pass tool response to 2nd llm to craft final response
         messages << first_reply
         case func
         when "get_weather_report"
           begin
             tool_response = get_weather_report(**args)
-            # Pass tool response to 2nd llm to craft final response
             pp "------------Tool response:-------------"
             pp tool_response if tool_response
             messages << T(tool_response, tool_call_id: tool_call_id, name: func)
@@ -122,7 +114,7 @@ class GroqchatService
 
   class RescueStream < GroqchatService
     def call
-      rescue_msg = A("Great question! As I am still a young LLM, I may not be able to answer your question or I sometimes get stuck. Could you try rephrasing or ask another question instead?")
+      rescue_msg = A("Erm...😬 as I am still a young 👼 LLM, I may not be able to answer your question or I sometimes get stuck. I'm so sorry 🙇🏻‍♂️ Could you try rephrasing or ask another question instead? You can also try resetting the chat. My makers are 🤡💩🤡")
       stream_direct(@response, rescue_msg)
     end
   end

--- a/app/views/conversations/_index.html.erb
+++ b/app/views/conversations/_index.html.erb
@@ -7,8 +7,10 @@
   </section>
 
   <div class="flex-shrink-0">
-    <%= simple_form_for [ chat, conversation ], data: { action: "conversation#generateResponse" } do |f| %>
-      <%= f.input :user_message, label: "ask me anything", as: :string, input_html: { data: { conversation_target: "prompt" } } %>
+    <%= form_with html: {class: "mb-4", data: { action: "conversation#generateResponse" }}  do |f| %>
+      <%= f.label :message, "ask me anything" %>
+      <%= f.text_field :message, { data: { conversation_target: "prompt" }, class: "form-control"} %>
     <% end %>
+    <button class="btn btn-primary" data-action="click->conversation#resetChat">Reset Chat</button>
   </div>
 </div>

--- a/app/views/conversations/_index.html.erb
+++ b/app/views/conversations/_index.html.erb
@@ -7,10 +7,10 @@
   </section>
 
   <div class="flex-shrink-0">
-    <%= form_with html: {class: "mb-4", data: { action: "conversation#generateResponse" }}  do |f| %>
+    <%= form_with html: {class: "mb-2", data: { action: "conversation#generateResponse" }}  do |f| %>
       <%= f.label :message, "ask me anything" %>
       <%= f.text_field :message, { data: { conversation_target: "prompt" }, class: "form-control"} %>
     <% end %>
-    <button class="btn btn-primary" data-action="click->conversation#resetChat">Reset Chat</button>
+    <button class="btn btn-primary btn-sm mb-2" data-action="click->conversation#resetChat">reset chat</button>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,8 @@ Rails.application.routes.draw do
       get 'original'
     end
   end
-  resources :chats, only: [ :index, :show, :create, :delete ] do
-    resources :conversations, only: [ :index, :new, :create, :show ]
+  resources :chats, only: [ :index, :create ] do
+    resources :conversations, only: [ :index ]
   end
   resources :conversation_responses, only: [ :index ]
 

--- a/db/migrate/20240614024025_add_message_to_conversations.rb
+++ b/db/migrate/20240614024025_add_message_to_conversations.rb
@@ -1,0 +1,7 @@
+class AddMessageToConversations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conversations, :message, :jsonb
+    remove_column :conversations, :user_message, :text
+    remove_column :conversations, :ai_message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_11_055300) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_14_024025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,11 +51,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_055300) do
   end
 
   create_table "conversations", force: :cascade do |t|
-    t.text "user_message"
-    t.text "ai_message"
     t.bigint "chat_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "message"
     t.index ["chat_id"], name: "index_conversations_on_chat_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,11 +22,7 @@ alexis = User.create!(email: 'alexis@test.com', password: '123abc')
 
 puts 'creating new chat'
 
-chat = Chat.create!(user: alexis)
-
-puts 'creating new conversation'
-
-Conversation.create!(user_message: "Tell me a joke", ai_message: "Knock knock! Who's there? Said the knocker.", chat: chat)
+Chat.create!(user: alexis)
 
 puts 'creating new tasks'
 

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ChatsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Assistant can now retain memory of past conversation. Able to know what user is referring to from past mentions.

Technical flow:
1. When Conversation stimulus controller is connected, a new Chat is initialised
2. The chat id is passed in the params to Conversation Responses controller which passes it to the groq service
3.  Groq service sets memory store to be the Chat object by that id
4. Conversations in each groq service call are stored as Conversation objects linked to the Chat id
- User prompt
- Assistant response
5. User can press Reset chat button on the chat form which will initialise a new Chat
