### PR TITLE
Sketchpad

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -6,3 +6,8 @@
   color: #339989
 }
 
+// removed the tick.
+.form-control {
+  background-color: initial !important;
+  background-image: none !important;
+}

--- a/app/assets/stylesheets/components/_showpage.scss
+++ b/app/assets/stylesheets/components/_showpage.scss
@@ -16,7 +16,7 @@
 
 .task-description {
   width: 100%;
-  height: 350px;
+  // height: 350px;
 }
 
 // .edit {

--- a/app/assets/stylesheets/components/_showpage.scss
+++ b/app/assets/stylesheets/components/_showpage.scss
@@ -15,8 +15,7 @@
 }
 
 .task-description {
-  width: 100%;
-  // height: 350px;
+  border: 1px solid black;
 }
 
 // .edit {

--- a/app/assets/stylesheets/components/_showpage.scss
+++ b/app/assets/stylesheets/components/_showpage.scss
@@ -18,6 +18,14 @@
   border: 1px solid black;
 }
 
+.task-documents {
+  overflow-x: scroll;
+}
+
+.task-icons-wrapper {
+  z-index: 10;
+}
+
 // .edit {
 //   position: fixed;
 //   top: 50px;

--- a/app/javascript/controllers/task_cards_controller.js
+++ b/app/javascript/controllers/task_cards_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="task-cards"
 export default class extends Controller {
-  static targets = ["content", "checkbox", "newcontent", "insertform"]
+  static targets = ["content", "checkbox", "newcontent", "insertform", "textarea"]
   static values = { id: String };
 
   connect() {
@@ -33,8 +33,6 @@ export default class extends Controller {
 
 submit(e) {
   e.preventDefault()
-  console.log('can it click');
-  console.log(e.currentTarget);
   const cardActive = e.currentTarget.closest('div[data-id]')
 
   fetch(e.currentTarget.action, {
@@ -80,10 +78,21 @@ openCard(e) {
 
 closeCard(e) {
   const cardActive = e.currentTarget.closest('div[data-id]')
-  cardActive.classList.remove("active")
   const id = cardActive.dataset.id
-  this.getOriginalContent(id, cardActive)
+
+  fetch(this.textareaTarget.action, {
+    method: this.textareaTarget.method,
+    headers: { "Accept": "application/json" },
+    body: new FormData(this.textareaTarget)
+  })
+  .then(response => response.json())
+  .then((data) => {
+    cardActive.classList.remove("active")
+    cardActive.innerHTML = data.updated_form
+    this.getOriginalContent(id, cardActive)
+  })
 }
+
 
 // load edit page
 // press the icon, card should zoom in

--- a/app/javascript/controllers/task_cards_controller.js
+++ b/app/javascript/controllers/task_cards_controller.js
@@ -33,6 +33,8 @@ export default class extends Controller {
 
 submit(e) {
   e.preventDefault()
+  console.log('can it click');
+  console.log(e.currentTarget);
   const cardActive = e.currentTarget.closest('div[data-id]')
 
   fetch(e.currentTarget.action, {

--- a/app/views/tasks/_show.html.erb
+++ b/app/views/tasks/_show.html.erb
@@ -33,17 +33,19 @@
   <%# to delete %>
 
 
-  <div class="d-flex justify-content-between align-items-end mt-2">
-    <% @task.documents.each do |doc| %>
-      <% url = cloudinary_url(doc.key) %>
-      <% image_url = url.sub('/upload/', '/upload/f_jpg/') %>
+  <div class="d-flex justify-content-end align-items-end mt-2">
+    <div class="flex-grow-1 d-flex align-items-center task-documents">
+      <% @task.documents.each do |doc| %>
+        <% url = cloudinary_url(doc.key) %>
+        <% image_url = url.sub('/upload/', '/upload/f_jpg/') %>
 
-      <div class="col-3 card border-0 mx-1">
-        <a href="<%= url %>"><img src="<%= image_url %>" class="w-100 border" alt=""></a>
-      </div>
-    <% end %>
+        <div class="col-3 card border-0 mx-1">
+          <a href="<%= url %>"><img src="<%= image_url %>" class="w-100 border" alt=""></a>
+        </div>
+      <% end %>
+    </div>
 
-    <div>
+    <div class="task-icons-wrapper">
       <p class="task-icons" data-action="click->task-cards#closeCard"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
 
       <%= render "tasks/checkbox", task: task %>

--- a/app/views/tasks/_show.html.erb
+++ b/app/views/tasks/_show.html.erb
@@ -18,7 +18,17 @@
   </div>
 
   <h1><%= @task.title %></h1>
-  <textarea class="task-description flex-grow-1" name="" id=""><%= @task.description %></textarea>
+
+  <%= simple_form_for @task,
+  html: {
+    class: 'flex-grow-1 d-flex flex-column' },
+  data: {
+        action: ("submit->task-cards#submit")
+    } do |f| %>
+  <%= f.input :description, as: :text, input_html: { class: 'flex-grow-1 task-description' }, wrapper_html: { class: 'flex-grow-1 d-flex flex-column' } %>
+  <%= f.submit 'Save' %>
+  <% end %>
+
   <%# to delete %>
 
 
@@ -33,7 +43,7 @@
     <% end %>
 
     <div>
-      <p class="task-icons" data-action="click->task-cards#closeCard"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
+      <p class="task-icons" data-action="click->task-cards#submit"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
 
       <%= render "tasks/checkbox", task: task %>
 

--- a/app/views/tasks/_show.html.erb
+++ b/app/views/tasks/_show.html.erb
@@ -20,8 +20,10 @@
       </div>
 
       <h1><%= @task.title %></h1>
+      <textarea class="task-description" name="" id=""><%= @task.description %></textarea>
+      <%# to delete %>
       <div class="task-description overflow-auto">
-        <p><%= @task.description %></p>
+        <p><% @task.description %></p>
       </div>
 
       <div class="d-flex position-absolute bottom-0">

--- a/app/views/tasks/_show.html.erb
+++ b/app/views/tasks/_show.html.erb
@@ -23,7 +23,8 @@
   html: {
     class: 'flex-grow-1 d-flex flex-column' },
   data: {
-        action: ("submit->task-cards#submit")
+        action: ("submit->task-cards#submit"),
+        task_cards_target: "textarea"
     } do |f| %>
   <%= f.input :description, as: :text, input_html: { class: 'flex-grow-1 task-description' }, wrapper_html: { class: 'flex-grow-1 d-flex flex-column' } %>
   <%= f.submit 'Save' %>
@@ -43,7 +44,7 @@
     <% end %>
 
     <div>
-      <p class="task-icons" data-action="click->task-cards#submit"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
+      <p class="task-icons" data-action="click->task-cards#closeCard"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
 
       <%= render "tasks/checkbox", task: task %>
 

--- a/app/views/tasks/_show.html.erb
+++ b/app/views/tasks/_show.html.erb
@@ -1,45 +1,38 @@
-<div class="container p-2" style="height: 100%;">
-  <div class="row" style="height: 100%;">
-    <div class="col-11 position-relative">
-      <div>
-        <% if @task.priority %>
-          <% if @task.priority == "High" %>
-            <span class="rectangular-highlight bg-danger">
-                High priority
-            </span>
-          <% elsif @task.priority == "Medium" %>
-            <span class="rectangular-highlight bg-warning">
-                Medium priority
-            </span>
-          <% elsif @task.priority == "Low" %>
-            <span class="rectangular-highlight bg-success">
-                Low priority
-            </span>
-          <% end %>
-        <% end %>
+<div class="container px-2 d-flex flex-column" style="height: 100%;">
+  <div>
+    <% if @task.priority %>
+      <% if @task.priority == "High" %>
+        <span class="rectangular-highlight bg-danger">
+            High priority
+        </span>
+      <% elsif @task.priority == "Medium" %>
+        <span class="rectangular-highlight bg-warning">
+            Medium priority
+        </span>
+      <% elsif @task.priority == "Low" %>
+        <span class="rectangular-highlight bg-success">
+            Low priority
+        </span>
+      <% end %>
+    <% end %>
+  </div>
+
+  <h1><%= @task.title %></h1>
+  <textarea class="task-description flex-grow-1" name="" id=""><%= @task.description %></textarea>
+  <%# to delete %>
+
+
+  <div class="d-flex justify-content-between align-items-end mt-2">
+    <% @task.documents.each do |doc| %>
+      <% url = cloudinary_url(doc.key) %>
+      <% image_url = url.sub('/upload/', '/upload/f_jpg/') %>
+
+      <div class="col-3 card border-0 mx-1">
+        <a href="<%= url %>"><img src="<%= image_url %>" class="w-100 border" alt=""></a>
       </div>
+    <% end %>
 
-      <h1><%= @task.title %></h1>
-      <textarea class="task-description" name="" id=""><%= @task.description %></textarea>
-      <%# to delete %>
-      <div class="task-description overflow-auto">
-        <p><% @task.description %></p>
-      </div>
-
-      <div class="d-flex position-absolute bottom-0">
-        <% @task.documents.each do |doc| %>
-          <% url = cloudinary_url(doc.key) %>
-          <% image_url = url.sub('/upload/', '/upload/f_jpg/') %>
-
-          <div class="col-3 card border-0 mx-1">
-            <a href="<%= url %>"><img src="<%= image_url %>" class="w-100 border" alt=""></a>
-          </div>
-
-        <% end %>
-      </div>
-    </div>
-
-    <div class="col-1 d-flex flex-column justify-content-end">
+    <div>
       <p class="task-icons" data-action="click->task-cards#closeCard"><i class="fa-solid fa-arrow-up-right-from-square"></i></p>
 
       <%= render "tasks/checkbox", task: task %>
@@ -50,5 +43,8 @@
 
       <p data-action="click->task-cards#openEdit" class="task-icons"><i class="fa-regular fa-pen-to-square"></i></p>
     </div>
+
+
   </div>
+
 </div>


### PR DESCRIPTION
_mainly to showcase 'sketchpad' inside of show more details page._

**Changes i made:** 

1. edited individual show more details page to show a textarea box instead for the description. 
     - textarea box saves upon clicking the save button.
     - textarea box saves upon clicking the button to minimize pop up
     - changes made via textarea can still be seen when clicking on other buttons. 
     - realised that adding too many documents causes it to spill over to the outside of the card. changed it so that it scrolls to the side instead when there is too many documents. (side-scrolling not the most ideal, i know but the one that makes sense right now)
     
2. edited _show.html.erb
     - quite big changes as i reformatted the layout so that textarea's width fills up the entire card.

**Things to look into:** 

1. _show.html.erb
     - document displays still uses col-3, need to find a way to restrict document sizes to whatever sizing is available instead of col-3
          - don't want the area at the bottom to take up a fixed width as i want them to size accordingly to portrait / landscape versions of the document. 

2. add rich text editor to the page (can be done tomorrow)

3. do we still want to have the save button on the page. 

4. the outline of the textarea box....
     - outline is a class added via simple forms when class 'is-valid' is present
     - over-riding the class will affect the form on the edit page
     - currently i over-ride the form and removed the ticks do edit form doesn't have any ticks too. 

5. do we still want to have the editable description field in the edit form page. 

**Please check:**
1. if saving and closing buttons work
2. if form still works from edit page side 

